### PR TITLE
Do not attempt to set memory.swappiness to zero

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -15,7 +15,9 @@ func NewClient(docker dockerclient.Client) (*Client, error) {
 
 	// creates an ambassador container
 	conf := &dockerclient.ContainerConfig{}
-	conf.HostConfig = dockerclient.HostConfig{}
+	conf.HostConfig = dockerclient.HostConfig{
+		MemorySwappiness: -1,
+	}
 	conf.Entrypoint = []string{"/bin/sleep"}
 	conf.Cmd = []string{"86400"}
 	conf.Image = "gliderlabs/alpine:3.1"

--- a/runner/utils.go
+++ b/runner/utils.go
@@ -25,8 +25,9 @@ func toContainerConfig(n *parser.DockerNode) *dockerclient.ContainerConfig {
 		Cmd:        n.Command,
 		Entrypoint: n.Entrypoint,
 		HostConfig: dockerclient.HostConfig{
-			Privileged:  n.Privileged,
-			NetworkMode: n.Net,
+			Privileged:       n.Privileged,
+			NetworkMode:      n.Net,
+			MemorySwappiness: -1,
 		},
 	}
 


### PR DESCRIPTION
Some old-ish kernels, e.g. 3.13 (Ubuntu 14.04), have a cgroup limitation that [prevents memory.swappiness from being set within a Docker container][1]. This change explicitly disables setting memory.swappiness.

I suspect this bug was introduced by this commit:

https://github.com/samalba/dockerclient/commit/133d1830b81d5c95888f30d8987f8fbbf66909dc

The default initializer for the HostConfig struct sets MemorySwappiness to zero. This results in the Docker server attempting to set memory.swappiness to 0%.

[1]: https://github.com/opencontainers/runc/issues/16