### PR TITLE
Add credentials to pull images from docker private registries

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -12,7 +12,6 @@ type Client struct {
 }
 
 func NewClient(docker dockerclient.Client) (*Client, error) {
-
 	// creates an ambassador container
 	conf := &dockerclient.ContainerConfig{}
 	conf.HostConfig = dockerclient.HostConfig{
@@ -23,7 +22,7 @@ func NewClient(docker dockerclient.Client) (*Client, error) {
 	conf.Image = "gliderlabs/alpine:3.1"
 	conf.Volumes = map[string]struct{}{}
 	conf.Volumes["/drone"] = struct{}{}
-	info, err := Start(docker, conf, false)
+	info, err := Start(docker, conf, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -33,9 +32,9 @@ func NewClient(docker dockerclient.Client) (*Client, error) {
 
 // CreateContainer creates a container and internally
 // caches its container id.
-func (c *Client) CreateContainer(conf *dockerclient.ContainerConfig, name string) (string, error) {
+func (c *Client) CreateContainer(conf *dockerclient.ContainerConfig, name string, auth *dockerclient.AuthConfig) (string, error) {
 	conf.Env = append(conf.Env, "affinity:container=="+c.info.Id)
-	id, err := c.Client.CreateContainer(conf, name)
+	id, err := c.Client.CreateContainer(conf, name, auth)
 	if err == nil {
 		c.names = append(c.names, id)
 	}

--- a/docker/util.go
+++ b/docker/util.go
@@ -30,10 +30,10 @@ var (
 	}
 )
 
-func Run(client dockerclient.Client, conf *dockerclient.ContainerConfig, pull bool) (*dockerclient.ContainerInfo, error) {
+func Run(client dockerclient.Client, conf *dockerclient.ContainerConfig, auth *dockerclient.AuthConfig, pull bool) (*dockerclient.ContainerInfo, error) {
 
 	// fetches the container information.
-	info, err := Start(client, conf, pull)
+	info, err := Start(client, conf, auth, pull)
 	if err != nil {
 		return nil, err
 	}
@@ -81,25 +81,26 @@ func Run(client dockerclient.Client, conf *dockerclient.ContainerConfig, pull bo
 	}
 }
 
-func Start(client dockerclient.Client, conf *dockerclient.ContainerConfig, pull bool) (*dockerclient.ContainerInfo, error) {
+func Start(client dockerclient.Client, conf *dockerclient.ContainerConfig, auth *dockerclient.AuthConfig, pull bool) (*dockerclient.ContainerInfo, error) {
+
 	// force-pull the image if specified.
 	if pull {
 		log.Printf("Pulling image %s", conf.Image)
-		client.PullImage(conf.Image, nil)
+		client.PullImage(conf.Image, auth)
 	}
 
 	// attempts to create the contianer
-	id, err := client.CreateContainer(conf, "")
+	id, err := client.CreateContainer(conf, "", auth)
 	if err != nil {
 		log.Printf("Pulling image %s", conf.Image)
 
 		// and pull the image and re-create if that fails
-		err = client.PullImage(conf.Image, nil)
+		err = client.PullImage(conf.Image, auth)
 		if err != nil {
 			log.Errorf("Error pulling %s. %s\n", conf.Image, err)
 			return nil, err
 		}
-		id, err = client.CreateContainer(conf, "")
+		id, err = client.CreateContainer(conf, "", auth)
 		if err != nil {
 			log.Errorf("Error creating %s. %s\n", conf.Image, err)
 			client.RemoveContainer(id, true, true)

--- a/parser/node.go
+++ b/parser/node.go
@@ -60,6 +60,7 @@ type DockerNode struct {
 	Volumes     []string
 	ExtraHosts  []string
 	Net         string
+	AuthConfig  yaml.AuthConfig
 	Vargs       map[string]interface{}
 }
 
@@ -75,6 +76,7 @@ func newDockerNode(typ NodeType, c yaml.Container) *DockerNode {
 		Volumes:     c.Volumes,
 		ExtraHosts:  c.ExtraHosts,
 		Net:         c.Net,
+		AuthConfig:  c.AuthConfig,
 	}
 }
 

--- a/runner/build.go
+++ b/runner/build.go
@@ -56,13 +56,16 @@ func (b *Build) walk(node parser.Node, state *State) (err error) {
 			break
 		}
 		// auth for accessing private docker registries
-		auth := &dockerclient.AuthConfig{
-			Username:      node.AuthConfig.Username,
-			Password:      node.AuthConfig.Password,
-			Email:         node.AuthConfig.Email,
-			RegistryToken: node.AuthConfig.RegistryToken,
+		var auth *dockerclient.AuthConfig
+		// auth to nil if password or token not set
+		if len(node.AuthConfig.Password) != 0 || len(node.AuthConfig.RegistryToken) != 0 {
+			auth = &dockerclient.AuthConfig{
+				Username:      node.AuthConfig.Username,
+				Password:      node.AuthConfig.Password,
+				Email:         node.AuthConfig.Email,
+				RegistryToken: node.AuthConfig.RegistryToken,
+			}
 		}
-
 		switch node.Type() {
 
 		case parser.NodeBuild:

--- a/yaml/parse_test.go
+++ b/yaml/parse_test.go
@@ -123,6 +123,10 @@ build:
     - /tmp/volumes
   net: bridge
   privileged: true
+  auth_config:
+    password: test
+    username: test
+    email: test@example.com
 
 compose:
   redis:

--- a/yaml/types.go
+++ b/yaml/types.go
@@ -25,6 +25,7 @@ type Container struct {
 	ExtraHosts  []string `yaml:"extra_hosts"`
 	Volumes     []string
 	Net         string
+	AuthConfig  AuthConfig `yaml:"auth_config"`
 }
 
 // Build is a typed representation of the build
@@ -33,6 +34,14 @@ type Build struct {
 	Container `yaml:",inline"`
 
 	Commands []string
+}
+
+// Auth for Docker Image Registry
+type AuthConfig struct {
+	Username      string `yaml:"username"`
+	Password      string `yaml:"password"`
+	Email         string `yaml:"email"`
+	RegistryToken string `yaml:"registry_token"`
 }
 
 // Plugin is a typed representation of a


### PR DESCRIPTION
I took a crack at this.  I've created 2 new variables `docker_username` and `docker_password`. 

I'll be honest I did not go into every plugin to check for conflicts, but I did check the most likely suspects. drone-docker and drone-dockerhub

```yaml
build:
  image: myrepo/project:0.0.1
  docker_username: jgreat
  docker_password: ***********
```
