### PR TITLE
apply mounts to containers for all nodes, not just build

### DIFF
--- a/parser/funcs.go
+++ b/parser/funcs.go
@@ -250,10 +250,8 @@ func Mount(n Node, from, to string) error {
 	if !ok {
 		return nil
 	}
-	if d.NodeType == NodeBuild {
-		dir := fmt.Sprintf("%s:%s", from, to)
-		d.Volumes = []string{dir}
-	}
+	dir := fmt.Sprintf("%s:%s", from, to)
+	d.Volumes = append(d.Volumes, dir)
 	return nil
 }
 


### PR DESCRIPTION
Prior to this change, if you ran `drone-exec --mount mydir`, then
mydir would only be mounted and available during the build. Plugins
would not have access to it. This is inconsistent with the behavior
when not using mount (when just using the ambassador container). Since
`--mount` is usually used to mount the actual source code (including
by `drone exec`), this breaks plugins when run with `drone exec`.

This issue was likely exposed by
https://github.com/drone/drone-cli/pull/14 because prior to that
change, it was not possible to pass `--deploy`, `--notify`, etc.,
options from `drone exec` to `drone-exec`.