### PR TITLE
Only configure apt-get when root

### DIFF
--- a/runner/script/const.go
+++ b/runner/script/const.go
@@ -59,10 +59,12 @@ EOF
 // to the build script to ensure apt-get installs
 // don't prompt the user to accept changes.
 const forceYesScript = `
+if [ "$(id -u)" = "0" ]; then
 mkdir -p /etc/apt/apt.conf.d
 cat <<EOF > /etc/apt/apt.conf.d/90forceyes
 APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
 EOF
+fi
 `
 
 // traceScript is a helper script that is added

--- a/runner/script/script.go
+++ b/runner/script/script.go
@@ -15,6 +15,7 @@ import (
 func Encode(w *plugin.Workspace, c *dockerclient.ContainerConfig, n *parser.DockerNode) {
 	var buf bytes.Buffer
 	buf.WriteString(setupScript)
+	buf.WriteString(forceYesScript)
 
 	if w != nil && w.Keys != nil && w.Netrc != nil {
 		buf.WriteString(writeKey(

--- a/runner/script/script_test.go
+++ b/runner/script/script_test.go
@@ -62,6 +62,11 @@ export PATH=$PATH:$GOBIN
 
 set -e
 
+mkdir -p /etc/apt/apt.conf.d
+cat <<EOF > /etc/apt/apt.conf.d/90forceyes
+APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
+EOF
+
 echo JCBnbyBidWlsZAo= | base64 -d
 go build
 
@@ -82,6 +87,11 @@ export PATH=$PATH:$GOBIN
 
 set -e
 
+mkdir -p /etc/apt/apt.conf.d
+cat <<EOF > /etc/apt/apt.conf.d/90forceyes
+APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
+EOF
+
 mkdir -p -m 0700 $HOME/.ssh
 cat <<EOF > $HOME/.ssh/id_rsa
 -----BEGIN RSA PRIVATE KEY----- MIIEpQIBAAKCAQEA3Tz2...
@@ -90,11 +100,6 @@ chmod 0600 $HOME/.ssh/id_rsa
 
 cat <<EOF > $HOME/.ssh/config
 StrictHostKeyChecking no
-EOF
-
-mkdir -p /etc/apt/apt.conf.d
-cat <<EOF > /etc/apt/apt.conf.d/90forceyes
-APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
 EOF
 
 cat <<EOF > $HOME/.netrc

--- a/runner/script/script_test.go
+++ b/runner/script/script_test.go
@@ -62,10 +62,12 @@ export PATH=$PATH:$GOBIN
 
 set -e
 
+if [ "$(id -u)" = "0" ]; then
 mkdir -p /etc/apt/apt.conf.d
 cat <<EOF > /etc/apt/apt.conf.d/90forceyes
 APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
 EOF
+fi
 
 echo JCBnbyBidWlsZAo= | base64 -d
 go build
@@ -87,10 +89,12 @@ export PATH=$PATH:$GOBIN
 
 set -e
 
+if [ "$(id -u)" = "0" ]; then
 mkdir -p /etc/apt/apt.conf.d
 cat <<EOF > /etc/apt/apt.conf.d/90forceyes
 APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
 EOF
+fi
 
 mkdir -p -m 0700 $HOME/.ssh
 cat <<EOF > $HOME/.ssh/id_rsa

--- a/runner/script/utils.go
+++ b/runner/script/utils.go
@@ -30,7 +30,6 @@ func writeKey(key string) string {
 	}
 	buf.WriteString(fmt.Sprintf(keyScript, key))
 	buf.WriteString(keyConfScript)
-	buf.WriteString(forceYesScript)
 	return buf.String()
 }
 

--- a/runner/script/utils_test.go
+++ b/runner/script/utils_test.go
@@ -69,11 +69,6 @@ chmod 0600 $HOME/.ssh/id_rsa
 cat <<EOF > $HOME/.ssh/config
 StrictHostKeyChecking no
 EOF
-
-mkdir -p /etc/apt/apt.conf.d
-cat <<EOF > /etc/apt/apt.conf.d/90forceyes
-APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
-EOF
 `
 
 var script = `


### PR DESCRIPTION
Based on feedback from https://github.com/drone/drone-exec/pull/9

This PR adds an optional `disable_apt_config` property under the `build` configuration to control whether the `/etc/apt/apt.conf.d/90forceyes` file is written.  When `disable_apt_config: true`, images that use non-root users will work properly.

**EDIT**: Update to this PR does not include any new configuration parameters, but simply skips apt configuration is the user is not `root`.