### PR TITLE
Update image build instructions to mirror .drone.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Docker image for the Drone build runner
-#
-#     CGO_ENABLED=0 go build -a -tags netgo
-#     docker build --rm=true -t drone/drone-exec .
+# Refer to README.md for instructions on how to build the image
 
 FROM gliderlabs/alpine:3.1
 RUN apk-install ca-certificates && rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the following commands to build the Docker image:
 
 ```sh
 # compile the binary for the correct architecture
-env GOOS=linux GOARCH=amd64 go build
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO15VENDOREXPERIMENT=1 go build
 
 # build the docker image, adding the above binary
 docker build --rm=true -t drone/drone-exec .
@@ -65,4 +65,3 @@ Using the `vexp` utility to vendor dependencies:
 go get https://github.com/kr/vexp
 ./vexp
 ```
-


### PR DESCRIPTION
While testing https://github.com/drone/drone-exec/pull/10 I ran into an issue where the instructions for building the docker container in the readme did not work. Updated the readme to match `.drone.yml` and `Dockerfile` to reference the instructions in the readme to reduce the number to update in the event that it changes.