### PR TITLE
allow specifying multiple netrc machine auth entries

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -23,16 +23,16 @@ import (
 // Payload defines the raw plugin payload that
 // stores the build metadata and configuration.
 type Payload struct {
-	Yaml      string            `json:"config"`
-	YamlEnc   string            `json:"secret"`
-	Repo      *plugin.Repo      `json:"repo"`
-	Build     *plugin.Build     `json:"build"`
-	BuildLast *plugin.Build     `json:"build_last"`
-	Job       *plugin.Job       `json:"job"`
-	Netrc     *plugin.Netrc     `json:"netrc"`
-	Keys      *plugin.Keypair   `json:"keys"`
-	System    *plugin.System    `json:"system"`
-	Workspace *plugin.Workspace `json:"workspace"`
+	Yaml      string               `json:"config"`
+	YamlEnc   string               `json:"secret"`
+	Repo      *plugin.Repo         `json:"repo"`
+	Build     *plugin.Build        `json:"build"`
+	BuildLast *plugin.Build        `json:"build_last"`
+	Job       *plugin.Job          `json:"job"`
+	Netrc     []*plugin.NetrcEntry `json:"netrc"`
+	Keys      *plugin.Keypair      `json:"keys"`
+	System    *plugin.System       `json:"system"`
+	Workspace *plugin.Workspace    `json:"workspace"`
 }
 
 // Options defines execution options.

--- a/runner/script/const.go
+++ b/runner/script/const.go
@@ -27,10 +27,11 @@ rm -rf $HOME/.ssh/id_rsa
 // the build script to enable cloning private git
 // repositories of http.
 const netrcScript = `
-cat <<EOF > $HOME/.netrc
+cat <<EOF >> $HOME/.netrc
 machine %s
 login %s
 password %s
+
 EOF
 chmod 0600 $HOME/.netrc
 `

--- a/runner/script/script.go
+++ b/runner/script/script.go
@@ -16,15 +16,19 @@ func Encode(w *plugin.Workspace, c *dockerclient.ContainerConfig, n *parser.Dock
 	var buf bytes.Buffer
 	buf.WriteString(setupScript)
 
-	if w != nil && w.Keys != nil && w.Netrc != nil {
-		buf.WriteString(writeKey(
-			w.Keys.Private,
-		))
-		buf.WriteString(writeNetrc(
-			w.Netrc.Machine,
-			w.Netrc.Login,
-			w.Netrc.Password,
-		))
+	if w != nil {
+		if w.Keys != nil {
+			buf.WriteString(writeKey(
+				w.Keys.Private,
+			))
+		}
+		for _, netrc := range w.Netrc {
+			buf.WriteString(writeNetrc(
+				netrc.Machine,
+				netrc.Login,
+				netrc.Password,
+			))
+		}
 	}
 
 	buf.WriteString(writeCmds(n.Commands))

--- a/runner/script/script_test.go
+++ b/runner/script/script_test.go
@@ -33,10 +33,17 @@ func Test_Rule(t *testing.T) {
 				Commands: []string{"go build", "go test"},
 			}
 			w := &plugin.Workspace{
-				Netrc: &plugin.Netrc{
-					Machine:  "foo",
-					Login:    "bar",
-					Password: "baz",
+				Netrc: []*plugin.NetrcEntry{
+					{
+						Machine:  "foo",
+						Login:    "bar",
+						Password: "baz",
+					},
+					{
+						Machine:  "qux",
+						Login:    "zip",
+						Password: "zap",
+					},
 				},
 				Keys: &plugin.Keypair{
 					Private: "-----BEGIN RSA PRIVATE KEY----- MIIEpQIBAAKCAQEA3Tz2...",
@@ -97,10 +104,19 @@ cat <<EOF > /etc/apt/apt.conf.d/90forceyes
 APT::Get::Assume-Yes "true";APT::Get::force-yes "true";
 EOF
 
-cat <<EOF > $HOME/.netrc
+cat <<EOF >> $HOME/.netrc
 machine foo
 login bar
 password baz
+
+EOF
+chmod 0600 $HOME/.netrc
+
+cat <<EOF >> $HOME/.netrc
+machine qux
+login zip
+password zap
+
 EOF
 chmod 0600 $HOME/.netrc
 

--- a/runner/script/utils_test.go
+++ b/runner/script/utils_test.go
@@ -51,10 +51,11 @@ func Test_Utils(t *testing.T) {
 }
 
 var netrc = `
-cat <<EOF > $HOME/.netrc
+cat <<EOF >> $HOME/.netrc
 machine foo
 login bar
 password baz
+
 EOF
 chmod 0600 $HOME/.netrc
 `


### PR DESCRIPTION
This is useful in the case that, e.g., your repository is hosted on host A and you want your build to be able to `go get` private repositories hosted on GitHub. In that case, you can supply netrc credentials both for host A and for GitHub.