### PR TITLE
use the project workspace dir as the working dir for deploy & publish

### DIFF
--- a/runner/build.go
+++ b/runner/build.go
@@ -115,6 +115,9 @@ func (b *Build) walk(node parser.Node, state *State) (err error) {
 		default:
 			conf := toContainerConfig(node)
 			conf.Cmd = toCommand(state, node)
+			if t := node.Type(); t == parser.NodeDeploy || t == parser.NodePublish {
+				conf.WorkingDir = state.Workspace.Path
+			}
 			info, err := docker.Run(state.Client, conf, auth, node.Pull, state.Stdout, state.Stderr)
 			if err != nil {
 				state.Exit(255)


### PR DESCRIPTION
Makes it easier to build custom deploy and publish steps by
eliminating the requirement for the deploy/publish Docker images to
parse the Drone payload to determine the working dir (which virtually
all of them would need to do). With this change, deploy and publish
Docker images need not even be Drone-aware (they can just perform an
action in the current directory).