### PR TITLE
make Default{Cloner,Cacher,Match} into vars (instead of consts)

### DIFF
--- a/parser/funcs.go
+++ b/parser/funcs.go
@@ -14,7 +14,7 @@ var (
 	ErrImageWhitelist = errors.New("Yaml must specify am image from the white-list")
 )
 
-const (
+var (
 	DefaultCloner = "plugins/drone-git"   // Default clone plugin.
 	DefaultCacher = "plugins/drone-cache" // Default cache plugin.
 	DefaultMatch  = "plugins/*"           // Default plugin whitelist.

--- a/runner/build.go
+++ b/runner/build.go
@@ -13,10 +13,10 @@ import (
 var ErrNoImage = errors.New("Yaml must specify an image for every step")
 
 // Default clone plugin.
-const DefaultCloner = "plugins/drone-git"
+var DefaultCloner = "plugins/drone-git"
 
 // Default cache plugin.
-const DefaultCacher = "plugins/drone-cache"
+var DefaultCacher = "plugins/drone-cache"
 
 type Build struct {
 	tree  *parser.Tree


### PR DESCRIPTION
Makes it easier to use drone-exec as a library from other Go code (when you need to use a different cloner, for example).