### PR TITLE
Improving the error message when the Yaml checksum validation fails

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -100,7 +100,7 @@ func Exec(payload Payload, opt Options, outw, errw io.Writer) error {
 			// deploy and notify tests.
 			opt.Deploy = false
 			opt.Notify = false
-			log.Errorln("Unable to validate Yaml checksum.", sec.Checksum)
+			log.Errorln("Unable to validate Yaml checksum. This means that secrets will not be injected. In addition the Deploy and Notify steps will not be executed. To resolve this please regenerate the secrets file.", sec.Checksum)
 		}
 	}
 


### PR DESCRIPTION
I was having an issue where my Docker publish was not running. After investigation it turned out that any change I made to the `.drone.yml` file caused me to have to regenerate the secrets file. I did not know this and the build log didn't tell me. So this PR is about making this more obvious to users without needing to dig through documentation or cry out for help on twitter/gitter/email/tin-cans/carrier-pidgen