### PR TITLE
attempt to resume tailing logs during builds

### DIFF
--- a/docker/util.go
+++ b/docker/util.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	// "strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/samalba/dockerclient"
@@ -57,32 +56,46 @@ func Run(client dockerclient.Client, conf *dockerclient.ContainerConfig, auth *d
 	errc := make(chan error, 1)
 	infoc := make(chan *dockerclient.ContainerInfo, 1)
 	go func() {
+		// It's possible that the docker logs endpoint returns before the container
+		// is done, we'll naively resume up to 5 times if when the logs unblocks
+		// the container is still reported to be running.
+		for attempts := 0; attempts < 5; attempts++ {
 
-		// blocks and waits for the container to finish
-		// by streaming the logs (to /dev/null). Ideally
-		// we could use the `wait` function instead
-		rc, err := client.ContainerLogs(info.Id, logOptsTail)
-		if err != nil {
-			log.Errorf("Error tailing %s. %s\n", conf.Image, err)
-			errc <- err
-			return
-		}
-		defer rc.Close()
-		_, err = StdCopy(outw, errw, rc)
-		if err != nil {
-			log.Errorf("Error streaming docker logs for %s. %s\n", conf.Image, err)
-			errc <- err
-			return
+			// blocks and waits for the container to finish
+			// by streaming the logs (to /dev/null). Ideally
+			// we could use the `wait` function instead
+			rc, err := client.ContainerLogs(info.Id, logOptsTail)
+			if err != nil {
+				log.Errorf("Error tailing %s. %s\n", conf.Image, err)
+				errc <- err
+				return
+			}
+			defer rc.Close()
+
+			_, err = StdCopy(outw, errw, rc)
+			if err != nil {
+				log.Errorf("Error streaming docker logs for %s. %s\n", conf.Image, err)
+				errc <- err
+				return
+			}
+
+			// fetches the container information
+			info, err := client.InspectContainer(info.Id)
+			if err != nil {
+				log.Errorf("Error getting exit code for %s. %s\n", conf.Image, err)
+				errc <- err
+				return
+			}
+
+			if !info.State.Running {
+				// The container is no longer running, there should be no more logs to tail.
+				infoc <- info
+				return
+			}
+			log.Debugf("Attempting to resume log tailing. Attempts %d.\n", attempts)
 		}
 
-		// fetches the container information
-		info, err := client.InspectContainer(info.Id)
-		if err != nil {
-			log.Errorf("Error getting exit code for %s. %s\n", conf.Image, err)
-			errc <- err
-			return
-		}
-		infoc <- info
+		errc <- errors.New("Maximum number of attempts made while tailing logs.")
 	}()
 
 	select {


### PR DESCRIPTION
We're getting quite a few failures due to the new code to catch early returns. While a red build is better than a false green it's also causing a lot of rebuilds. This is made worse when you realize the longer the build is the better the chance of hitting the error it seems.

This is my attempt to resume tailing the logs for our container if the tail ends and the container is still marked as running.

This will leak `rc`'s while we're doing attempts but I thought that was alright instead of messy code to clean them up.