### PR TITLE
Automatically give host system's storage driver as a varg to drone-docker

### DIFF
--- a/parser/funcs.go
+++ b/parser/funcs.go
@@ -158,6 +158,26 @@ func Escalate(n Node) error {
 	return nil
 }
 
+func StorageDriver(n Node, storageDriver string) error {
+	d, ok := n.(*DockerNode)
+	if !ok {
+		return nil
+	}
+	image := strings.Split(d.Image, ":")
+	if d.NodeType == NodePublish && (image[0] == "plugins/drone-docker") {
+		if d.Vargs["storage_driver"] == nil {
+			d.Vargs["storage_driver"] = storageDriver
+		}
+	}
+	return nil
+}
+
+func StorageDriverFunc(storageDriver string) RuleFunc {
+	return func(n Node) error {
+		return StorageDriver(n, storageDriver)
+	}
+}
+
 func DefaultNotifyFilter(n Node) error {
 	f, ok := n.(*FilterNode)
 	if !ok || f.Node == nil {


### PR DESCRIPTION
On a host system with the overlayfs storage driver, I had to manually set the storage driver to `overlay` for the docker publish step to work. As this is a per-repository configuration option, it is currently impossible to have build slaves with different storage drivers.

With this change, the docker instance inside the drone-docker container is run with the same storage driver as the host system, thus alleviating any mismatches. This also means the `storage_driver` should not need to be set manually anymore.