### PR TITLE
CI_TAG environment variable is not an int

### DIFF
--- a/runner/utils.go
+++ b/runner/utils.go
@@ -111,7 +111,7 @@ func toEnv(s *State) []string {
 		envs = append(envs, fmt.Sprintf("CI_PULL_REQUEST=%s", pullRegexp.FindString(s.Build.Ref)))
 		envs = append(envs, fmt.Sprintf("DRONE_PULL_REQUEST=%s", pullRegexp.FindString(s.Build.Ref)))
 	}
-	
+
 	if s.Build.Event == "deployment" {
 		envs = append(envs, fmt.Sprintf("CI_DEPLOY_TO=%s", s.Build.Deploy))
 		envs = append(envs, fmt.Sprintf("DRONE_DEPLOY_TO=%s", s.Build.Deploy))
@@ -124,7 +124,7 @@ func toEnv(s *State) []string {
 
 	if s.Build.Event == plugin.EventTag {
 		tag := strings.TrimPrefix(s.Build.Ref, "refs/tags/")
-		envs = append(envs, fmt.Sprintf("CI_TAG=%d", tag))
+		envs = append(envs, fmt.Sprintf("CI_TAG=%s", tag))
 		envs = append(envs, fmt.Sprintf("DRONE_TAG=%s", tag))
 	}
 


### PR DESCRIPTION
Currently we are setting DRONE_TAG correctly to a string while we are
setting CI_TAG to a decimal value, with that commit I have replaced the
decimal value with a string value.

Signed-off-by: Thomas Boerger <tboerger@suse.de>